### PR TITLE
Fix buffer overflow

### DIFF
--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -251,7 +251,7 @@ int ret;
 			} else {
 				str = mdb_col_to_string(mdb, mdb->pg_buf, start, col->col_type, len);
 			}
-			strcpy(col->bind_ptr, str);
+			g_snprintf(col->bind_ptr, MDB_BIND_SIZE, "%s", str);
 			g_free(str);
 		}
 		ret = strlen(col->bind_ptr);


### PR DESCRIPTION
If the string version of the column data exceeds `MDB_BIND_SIZE`, a buffer overflow occurs.

This change uses `g_snprintf` to ensure that the string always fits into the destination and is null-terminated.